### PR TITLE
Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,12 @@ FROM scratch
 
 # Copy Binary From Builder
 COPY --from=builder /go/src/github.com/Tri125/HoP/HoP /app/
-WORKDIR /app
 
 # Copy In Certificates
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Set Working Directory
+WORKDIR /app
 
 # Entrypoint/CMD
 CMD ["./HoP"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build App Using golang Image  
+FROM golang:latest as builder
+
+# Add Source Code
+WORKDIR /go/src/github.com/Tri125/HoP
+COPY . .
+
+# Get Dependencies
+RUN go get -u github.com/golang/dep/cmd/dep
+RUN $GOPATH/bin/dep ensure --vendor-only
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o HoP .
+
+# Create Lightweight Docker Image 
+FROM scratch
+
+# Copy Binary From Builder
+COPY --from=builder /go/src/github.com/Tri125/HoP/HoP /app/
+WORKDIR /app
+
+# Copy In Certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Entrypoint/CMD
+CMD ["./HoP"]


### PR DESCRIPTION
This creates a small docker image that can be easily run and distributed.  The project can be setup to be automatically built and uploaded to docker hub for free.  It can be set so that an update to master (or any tag) triggers a rebuild.

- https://docs.docker.com/docker-hub/builds/
- https://hub.docker.com/

This makes deploying the bot super easy/simple by using docker.  If you want the bot to be accessible for other to easily deploy this is the best way to go.

To Manually Build & Run:
```
cd ~/sourceDirectoryWhereverThatIs
docker build -t HoP:1.0 .
docker run -e "HOP_TOKEN=kjlkj;kjeiowhatever" HoP:1.0
```
This will run in the foreground and stop when you hit "Ctrl+c"

If you don't want to bother with docker hub automated builds then you can use Travis CI to test and publish to docker hub instead.

- https://docs.travis-ci.com/user/docker/ 
- https://bencane.com/2016/01/11/using-travis-ci-to-test-docker-builds/